### PR TITLE
Emulate old behavior for git+https:// urls and just warn about it

### DIFF
--- a/normalize-git-url.js
+++ b/normalize-git-url.js
@@ -18,7 +18,12 @@ module.exports = function normalize (u) {
 
   var returnedUrl
   if (parsed.pathname.match(/\/?:/)) {
-    returnedUrl = u.replace(/^(?:git\+)?ssh:\/\//, '').replace(/#[^#]*$/, '')
+    if (u.match(/^git\+https?/) && parsed.pathname.match(/\/?:[^0-9]/)) {
+      returnedUrl = u.replace(/^git\+(.*:[^:]+):(.*)/, '$1/$2')
+    } else {
+      returnedUrl = u.replace(/^(?:git\+)?ssh:\/\//, '')
+    }
+    returnedUrl = returnedUrl.replace(/#[^#]*$/, '')
   } else {
     returnedUrl = url.format(parsed)
   }

--- a/test/basic.js
+++ b/test/basic.js
@@ -17,7 +17,7 @@ test('basic normalization tests', function (t) {
   )
   t.same(
     normalize('git+https://user@hostname:project/blah.git#commit-ish'),
-    { url: 'https://user@hostname:project/blah.git', branch: 'commit-ish' }
+    { url: 'https://user@hostname/project/blah.git', branch: 'commit-ish' }
   )
   t.same(
     normalize('git+ssh://git@github.com:npm/npm.git#v1.0.27'),


### PR DESCRIPTION
Before my big `git` fix, we were accepting bad-format `git+https://` URLs and converting them to use absolute paths during normalization. This brings back only that specific old behavior, and warns about its deprecation.

Note: idk what the _proper_ way to deprecate is, and I assume it's not a `console.warn`?
